### PR TITLE
PATCH - Performance can be increased if replaceAll() does not use a r…

### DIFF
--- a/org.apache.ace.log.server.ui/src/org/apache/ace/log/server/ui/LogViewerExtension.java
+++ b/org.apache.ace.log.server.ui/src/org/apache/ace/log/server/ui/LogViewerExtension.java
@@ -264,6 +264,6 @@ public class LogViewerExtension implements UIExtensionFactory {
     }
 
     private String normalize(String input) {
-        return input.toLowerCase().replaceAll("_", " ");
+        return input.toLowerCase().replace("_", " ");
     }
 }


### PR DESCRIPTION
…egex by replacing replaceAll() with replace(). ReplaceAll() costs some performance overhead by compiling the regex whereas replace() does not incur this performance overhead.